### PR TITLE
Add reference to Circuitron

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/j
 + [Import-LIB-KiCad-Plugin](https://github.com/Steffen-W/Import-LIB-KiCad-Plugin): Import KiCad component libraries imported from Ultralibrarian and SnapEDA zipfiles.
 + [typeCAD](https://github.com/typecad/typecad): Programmatically create hardware designs with TypeScript. Create/reuse/import version-controlled packages between projects. 
 + [SKiDL](https://github.com/devbisme/skidl): A module that extends Python with the ability to design electronic circuits.
-
++ [Circuitron](https://github.com/Shaurya-Sethi/circuitron): Agentic PCB Design Accelerator — Generate, plan, and layout circuits from natural language prompts.
 
 ##### Presentations
 + [InteractiveHtmlBom](https://github.com/openscopeproject/InteractiveHtmlBom): Generate convenient BOM listing with ability to visually correlate and easily search for components and their placements on the pcb


### PR DESCRIPTION
- https://github.com/Shaurya-Sethi/circuitron

> Circuitron is an agent-driven PCB design accelerator that converts natural language requirements into SKiDL scripts, KiCad schematics, and PCB layout files. It integrates a multi-agent pipeline with advanced reasoning and retrieval-augmented capabilities.