### PR TITLE
Add API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Please take a quick gander at the [contribution guidelines](https://github.com/j
 
 ### Contents
 
+#### API
+
++ [`kicad-python`](https://gitlab.com/kicad/code/kicad-python): Official Python bindings for the KiCad IPC API.
++ [`kicad-rs`](https://gitlab.com/kicad/code/kicad-rs): Official Rust bindings for the KiCad IPC API.
+
 #### Plugins
 
 ##### Panelization


### PR DESCRIPTION
Added API section with links to Python and Rust bindings for KiCad IPC API.

- https://gitlab.com/kicad/code/kicad-python
- https://gitlab.com/kicad/code/kicad-rs
- https://dev-docs.kicad.org/en/apis-and-binding/ipc-api/index.html